### PR TITLE
Fix: Add missing properties to pluginst.inf

### DIFF
--- a/resources/pluginst.inf
+++ b/resources/pluginst.inf
@@ -1,4 +1,6 @@
 [plugininstall]
+version=1.0.0
+defaultdir=PlantUmlWebView
 type=wlx64
 file=PlantUmlWebView.wlx64
 name=PlantUML WebView Lister


### PR DESCRIPTION
Total Commander's automatic plugin installation from a ZIP archive requires the `pluginst.inf` file to contain a `defaultdir` property, which specifies the directory where the plugin should be installed. This property was missing, which prevented the installation prompt from appearing.

This change adds the `defaultdir` and `version` properties to `resources/pluginst.inf` to enable auto-installation and provide versioning for the plugin.