### PR TITLE
Update release pipeline with PlantUML refresh

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -30,6 +30,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install PlantUML update dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install requests
+
+      - name: Update PlantUML artifacts
+        run: python scripts/update_plantuml.py
+
+      - name: Check PlantUML update status
+        id: plantuml_update
+        run: |
+          $status = git status --porcelain third_party plantumlwebview.ini
+          $jar = Get-ChildItem -Path third_party -Filter 'plantuml-mit-*.jar' | Sort-Object Name -Descending | Select-Object -First 1
+          if ($null -ne $jar) {
+            "jar=$($jar.Name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          }
+          if ([string]::IsNullOrWhiteSpace($status)) {
+            "updated=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } else {
+            "updated=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          }
+
       - name: Install tools
         run: |
           choco install ninja -y
@@ -139,6 +166,29 @@ jobs:
           }
           "tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
+      - name: Generate release notes
+        id: release_notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $tag = "${{ steps.tag.outputs.tag }}"
+          $target = "${{ github.sha }}"
+          $headers = @{
+            Authorization = "Bearer $env:GITHUB_TOKEN"
+            Accept        = "application/vnd.github+json"
+            'X-GitHub-Api-Version' = '2022-11-28'
+          }
+          $payload = @{ tag_name = $tag; target_commitish = $target } | ConvertTo-Json -Compress
+          $response = Invoke-RestMethod -Uri "https://api.github.com/repos/${{ github.repository }}/releases/generate-notes" -Method Post -Headers $headers -Body $payload -ContentType 'application/json'
+          $notes = $response.body
+          if ("${{ steps.plantuml_update.outputs.updated }}" -eq "true") {
+            $jarName = "${{ steps.plantuml_update.outputs.jar }}"
+            $updateNote = "### PlantUML Update`n- Updated bundled PlantUML jar to `$jarName` during this release.`n"
+            $notes = "$updateNote`n$notes"
+          }
+          Set-Content -Path release_notes.md -Value $notes
+          "path=release_notes.md" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -147,4 +197,4 @@ jobs:
           draft: ${{ github.event.inputs.draft || 'true' }}
           files: |
             PlantUmlWebView.zip
-          generate_release_notes: true
+          body_path: ${{ steps.release_notes.outputs.path }}


### PR DESCRIPTION
## Summary
- add PlantUML update check to the release workflow and reuse the update script
- generate release notes via the GitHub API and prepend a PlantUML update note when applicable
- switch the release creation step to use the generated notes file

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cf52f6bdd4832280642a4bfb3ef4d3