### PR TITLE
Add detailed logging for PlantUML rendering

### DIFF
--- a/plantumlwebview.ini
+++ b/plantumlwebview.ini
@@ -28,3 +28,7 @@ timeout_ms=8000
 [detect]
 ; Reported detect string for Total Commander installation
 string=EXT="PUML" | EXT="PLANTUML" | EXT="UML" | EXT="WSD" | EXT="WS" | EXT="IUML"
+
+[debug]
+; Optional log file path (defaults to plantumlwebview.log next to the plugin DLL)
+log=


### PR DESCRIPTION
## Summary
- add a configurable UTF-8 log writer that stamps each session and records pipeline events
- log configuration, file loading, Java invocation results, fallback selection, and WebView setup steps to help diagnose blank panels
- document the new optional `debug.log` entry in the sample INI file

## Testing
- not run (Windows-only plugin)


------
https://chatgpt.com/codex/tasks/task_e_68cf68439d848322b7982d0cee18aaee