### PR TITLE
Trigger release workflow on merges to main

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -11,6 +11,8 @@ on:
         required: true
         default: "true"
   push:
+    branches:
+      - main
     tags:
       - "v*"
       - "V*"


### PR DESCRIPTION
## Summary
- trigger the build and release workflow whenever changes land on the main branch
- keep existing manual dispatch and tag-based triggers intact

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d0b243c26c8322a6c56ed27ed34302