### PR TITLE
Trigger fallback when web renderer fetch fails

### DIFF
--- a/src/plantuml_wlx_ev2.cpp
+++ b/src/plantuml_wlx_ev2.cpp
@@ -925,6 +925,31 @@ static void InitWebView(struct Host* host){
                                                 HostTriggerFallback(host, detail);
                                             } else if (tag == L"web-fetch") {
                                                 AppendLog(L"InitWebView: Web fetch detail -> " + detail);
+                                                if (!detail.empty()) {
+                                                    bool isFailure = (detail.rfind(L"failure", 0) == 0);
+                                                    if (!isFailure) {
+                                                        const std::wstring lowerDetail = ToLowerTrim(detail);
+                                                        isFailure = (lowerDetail.rfind(L"failure", 0) == 0);
+                                                    }
+                                                    if (isFailure) {
+                                                        std::wstring reason = detail;
+                                                        const std::wstring marker = L"message=";
+                                                        size_t pos = reason.find(marker);
+                                                        if (pos != std::wstring::npos) {
+                                                            reason = reason.substr(pos + marker.size());
+                                                            while (!reason.empty() && iswspace(reason.front())) {
+                                                                reason.erase(reason.begin());
+                                                            }
+                                                            while (!reason.empty() && iswspace(reason.back())) {
+                                                                reason.pop_back();
+                                                            }
+                                                            if (reason.empty()) {
+                                                                reason = L"web renderer error";
+                                                            }
+                                                        }
+                                                        HostTriggerFallback(host, reason);
+                                                    }
+                                                }
                                             } else if (!message.empty()) {
                                                 AppendLog(L"InitWebView: Web message -> " + message);
                                             }


### PR DESCRIPTION
## Summary
- trigger the Java fallback whenever the web renderer reports a fetch failure
- extract a readable error message from the failure payload before passing it to the fallback handler
- trim the message so that error dialogs show a clean reason when web rendering fails

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: linux environment lacks windows.h)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b9f4fea083229fa3b7267b6dda87