### PR TITLE
Include PlantUML jar in release package

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -137,6 +137,12 @@ jobs:
           if (!(Test-Path $wv2)) { throw "WebView2Loader.dll not found at $wv2" }
           Copy-Item -Force $wv2 $stage\
 
+          $plantumlJar = Get-ChildItem -Path third_party -Filter 'plantuml-mit-*.jar' | Sort-Object Name -Descending | Select-Object -First 1
+          if ($null -eq $plantumlJar) {
+            throw "PlantUML jar (plantuml-mit-*.jar) not found in third_party"
+          }
+          Copy-Item -Force $plantumlJar.FullName $stage\
+
       - name: Create ZIP (no nesting)
         run: |
           Set-StrictMode -Version Latest


### PR DESCRIPTION
## Summary
- copy the bundled PlantUML jar into the staged release package so it is included in the zip asset
- fail fast if the jar is missing so release jobs surface the problem immediately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0d84ad0c083229d0c9d1b1a4557a1