### PR TITLE
Add ini toggle for debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ string=EXT="PUML" | EXT="PLANTUML" | EXT="UML" | EXT="WSD" | EXT="WS" | EXT="IUM
 
 [debug]
 ; Optional log file path (defaults next to the plugin DLL)
+; Set log_enabled=0 to disable logging entirely
+log_enabled=1
 log=
 ```
 
@@ -96,7 +98,7 @@ All rendering happens locally via Java and `plantuml.jar`; the plugin does not p
 * **Blank panel / “Render error”**
 
   * Verify Java and `plantuml.jar` paths in `[plantuml]` are correct.
-  * Enable logging via `[debug] log=` and inspect `plantumlwebview.log` for details.
+* **Logging** – keep `[debug] log_enabled=1` (default) and inspect `plantumlwebview.log` (or a custom `[debug] log=` path) for details.
 * **“WebView2 Runtime not found”**
 
   * Install the **WebView2 Runtime (Evergreen)** from Microsoft (link above) and retry.

--- a/plantumlwebview.ini
+++ b/plantumlwebview.ini
@@ -22,4 +22,6 @@ string=EXT="PUML" | EXT="PLANTUML" | EXT="UML" | EXT="WSD" | EXT="WS" | EXT="IUM
 
 [debug]
 ; Optional log file path (defaults to plantumlwebview.log next to the plugin DLL)
+; Set log_enabled=0 to disable logging entirely
+log_enabled=1
 log=

--- a/src/plantuml_wlx_ev2.cpp
+++ b/src/plantuml_wlx_ev2.cpp
@@ -33,6 +33,7 @@ static std::wstring g_jarPath;                      // If empty: auto-detect mod
 static std::wstring g_javaPath;                     // Optional explicit java[w].exe
 static std::wstring g_logPath;                      // If empty: moduleDir\plantumlwebview.log
 static DWORD        g_jarTimeoutMs = 8000;
+static bool         g_logEnabled = true;
 
 static bool         g_cfgLoaded = false;
 
@@ -51,7 +52,7 @@ static std::wstring FormatTimestamp() {
 }
 
 static void AppendLog(const std::wstring& message) {
-    if (g_logPath.empty()) return;
+    if (!g_logEnabled || g_logPath.empty()) return;
     std::lock_guard<std::mutex> lock(g_logMutex);
     HANDLE h = CreateFileW(g_logPath.c_str(), FILE_APPEND_DATA, FILE_SHARE_READ, nullptr,
                            OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
@@ -201,9 +202,6 @@ static void LoadConfigIfNeeded() {
 
     const std::wstring moduleDir = GetModuleDir();
     const std::wstring ini = moduleDir + L"\\plantumlwebview.ini";
-    if (g_logPath.empty()) {
-        g_logPath = moduleDir + L"\\plantumlwebview.log";
-    }
     wchar_t buf[2048];
 
     if (GetPrivateProfileStringW(L"render", L"prefer", L"", buf, 2048, ini.c_str()) > 0 && buf[0]) g_prefer = buf;
@@ -230,11 +228,22 @@ static void LoadConfigIfNeeded() {
     DWORD tmo = GetPrivateProfileIntW(L"plantuml", L"timeout_ms", 0, ini.c_str());
     if (tmo > 0) g_jarTimeoutMs = tmo;
 
+    int logEnabled = GetPrivateProfileIntW(L"debug", L"log_enabled", 1, ini.c_str());
+    g_logEnabled = (logEnabled != 0);
+
     if (GetPrivateProfileStringW(L"debug", L"log", L"", buf, 2048, ini.c_str()) > 0 && buf[0]) {
         g_logPath = buf;
         if (PathIsRelativeW(g_logPath.c_str())) {
             g_logPath = moduleDir + L"\\" + g_logPath;
         }
+    }
+
+    if (g_logEnabled) {
+        if (g_logPath.empty()) {
+            g_logPath = moduleDir + L"\\plantumlwebview.log";
+        }
+    } else {
+        g_logPath.clear();
     }
 
     bool needDetectJar = g_jarPath.empty();
@@ -254,7 +263,8 @@ static void LoadConfigIfNeeded() {
         << L", jar=" << (g_jarPath.empty() ? L"<auto>" : g_jarPath)
         << L", java=" << (g_javaPath.empty() ? L"<auto>" : g_javaPath)
         << L", timeoutMs=" << g_jarTimeoutMs
-        << L", log=" << g_logPath;
+        << L", logEnabled=" << (g_logEnabled ? L"1" : L"0")
+        << L", log=" << (g_logPath.empty() ? L"<disabled>" : g_logPath);
     AppendLog(cfg.str());
 }
 


### PR DESCRIPTION
## Summary
- add a log_enabled toggle in the debug section of the ini file
- gate log writes on the new flag while still honoring custom log paths
- document the toggle in the sample ini and README troubleshooting guidance

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d0dae5d3648322b0bca4dbadc34933