### PR TITLE
Fix WebView handlers releasing host references

### DIFF
--- a/src/plantuml_wlx_ev2.cpp
+++ b/src/plantuml_wlx_ev2.cpp
@@ -1304,6 +1304,7 @@ static void InitWebView(struct Host* host){
                     HostAddRef(host);
                     auto webMessageHandler = Callback<ICoreWebView2WebMessageReceivedEventHandler>(
                         [host](ICoreWebView2*, ICoreWebView2WebMessageReceivedEventArgs* args) -> HRESULT {
+                            HostAddRef(host);
                             std::unique_ptr<Host, decltype(&HostRelease)> guard(host, &HostRelease);
                             if (!host || host->closing.load(std::memory_order_acquire)) {
                                 return S_OK;
@@ -1348,6 +1349,7 @@ static void InitWebView(struct Host* host){
                     HostAddRef(host);
                     auto navCompletedHandler = Callback<ICoreWebView2NavigationCompletedEventHandler>(
                         [host](ICoreWebView2*, ICoreWebView2NavigationCompletedEventArgs* args) -> HRESULT {
+                            HostAddRef(host);
                             std::unique_ptr<Host, decltype(&HostRelease)> guard(host, &HostRelease);
                             if(!host || host->closing.load(std::memory_order_acquire)){
                                 return S_OK;


### PR DESCRIPTION
## Summary
- add HostAddRef guard calls inside WebView message and navigation event handlers to balance reference counts
- prevent Host from being destroyed after handling a few WebView callbacks which blanked the panel

## Testing
- Not run (Windows-specific project)

------
https://chatgpt.com/codex/tasks/task_e_68d18eaf22dc83229ac3fb6316059a52