### PR TITLE
Fix missing PlantUML encoder injection in web renderer

### DIFF
--- a/src/plantuml_wlx_ev2.cpp
+++ b/src/plantuml_wlx_ev2.cpp
@@ -1520,6 +1520,7 @@ static bool BuildHtmlFromWebRender(const std::wstring& umlText,
 
     ReplaceAll(html, L"{{FORMAT}}", preferSvg ? L"svg" : L"png");
     ReplaceAll(html, L"{{SOURCE_NAME}}", safeSourceName);
+    ReplaceAll(html, L"{{PLANTUML_ENCODER}}", PlantumlEncoderScript());
     ReplaceAll(html, L"{{PLANTUML_SOURCE}}", escaped);
 
     outHtml.swap(html);


### PR DESCRIPTION
## Summary
- ensure the PlantUML encoder script is injected into the web rendering HTML shell so the encoder is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4bcb52bbc83229bd7e78b5a907d1e