### PR TITLE
Fix base64 decoding for web renderer outputs

### DIFF
--- a/src/plantuml_wlx_ev2.cpp
+++ b/src/plantuml_wlx_ev2.cpp
@@ -598,16 +598,18 @@ static std::vector<unsigned char> Base64Decode(const std::wstring& in) {
 
     unsigned int buffer = 0;
     int bitsCollected = 0;
+    bool hitPadding = false;
     for (wchar_t wc : in) {
         int decoded = Base64DecodeChar(wc);
         if (decoded < 0) {
             if (decoded == -1) {
                 if (bitsCollected == 18) {
-                    out.push_back(static_cast<unsigned char>((buffer >> 16) & 0xFF));
+                    out.push_back(static_cast<unsigned char>((buffer >> 10) & 0xFF));
+                    out.push_back(static_cast<unsigned char>((buffer >> 2) & 0xFF));
                 } else if (bitsCollected == 12) {
-                    out.push_back(static_cast<unsigned char>((buffer >> 16) & 0xFF));
-                    out.push_back(static_cast<unsigned char>((buffer >> 8) & 0xFF));
+                    out.push_back(static_cast<unsigned char>((buffer >> 4) & 0xFF));
                 }
+                hitPadding = true;
                 break;
             }
             continue;
@@ -622,6 +624,16 @@ static std::vector<unsigned char> Base64Decode(const std::wstring& in) {
             bitsCollected = 0;
         }
     }
+
+    if (!hitPadding) {
+        if (bitsCollected == 18) {
+            out.push_back(static_cast<unsigned char>((buffer >> 10) & 0xFF));
+            out.push_back(static_cast<unsigned char>((buffer >> 2) & 0xFF));
+        } else if (bitsCollected == 12) {
+            out.push_back(static_cast<unsigned char>((buffer >> 4) & 0xFF));
+        }
+    }
+
     return out;
 }
 


### PR DESCRIPTION
## Summary
- preserve the existing Base64 decoder structure while fixing its padding handling
- flush the remaining decoded bytes so web renderer payloads keep trailing markers such as `</svg>`

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4c44c2afc83228137b5ef2735aa32